### PR TITLE
Update connection string to enable connections to Supabase over IPv4 networks

### DIFF
--- a/judgment/self_host/supabase/supabase.py
+++ b/judgment/self_host/supabase/supabase.py
@@ -31,7 +31,7 @@ class SupabaseClient:
         host = "aws-0-us-west-1.pooler.supabase.com"
 
         # Final connection string
-        conn_str = f"postgresql://postgres.{project_ref}:{self.db_password}@{host}:5432/postgres"
+        conn_str = f"postgresql://postgres.{project_ref}:{self.db_password}@{host}:6543/postgres"
 
         # Connect
         conn = psycopg2.connect(conn_str)

--- a/judgment/self_host/supabase/supabase.py
+++ b/judgment/self_host/supabase/supabase.py
@@ -24,7 +24,17 @@ class SupabaseClient:
     @contextmanager
     def _get_db_connection(self, db_url: str):
         """Helper method to manage database connections and cursors."""
-        conn = psycopg2.connect(f"postgres://postgres:{self.db_password}@db.{db_url.replace('https://', '')}:5432/postgres")
+        # Extract project ref from db_url
+        project_ref = db_url.replace('https://', '').split('.')[0]
+
+        # Hardcoded host
+        host = "aws-0-us-west-1.pooler.supabase.com"
+
+        # Final connection string
+        conn_str = f"postgresql://postgres.{project_ref}:{self.db_password}@{host}:5432/postgres"
+
+        # Connect
+        conn =psycopg2.connect(conn_str)
         cursor = conn.cursor()
         try:
             yield cursor

--- a/judgment/self_host/supabase/supabase.py
+++ b/judgment/self_host/supabase/supabase.py
@@ -34,7 +34,7 @@ class SupabaseClient:
         conn_str = f"postgresql://postgres.{project_ref}:{self.db_password}@{host}:5432/postgres"
 
         # Connect
-        conn =psycopg2.connect(conn_str)
+        conn = psycopg2.connect(conn_str)
         cursor = conn.cursor()
         try:
             yield cursor


### PR DESCRIPTION
## 📝 Summary

Supabase recently pushed an update that restricts use of the direct connection string behind IPV6 requests. Because of this, the normal connection string wasn't being recognized as a valid host. This fix uses the session pooling string which Supabase indicates is an alternative to the direct connection string

## 🎯 Purpose

Supabase project creation section of the self host tool was breaking because of the faulty connection string.

## 🧪 Testing

Deployed and loaded schema onto new supabase project using new connection string